### PR TITLE
feat: Wire local PostgreSQL (env-driven) + docs — Docker later 😅

### DIFF
--- a/.devcontainer/docker/.env.example
+++ b/.devcontainer/docker/.env.example
@@ -1,0 +1,7 @@
+
+# db
+DB_HOST=
+DB_PORT=
+DB_NAME=
+DB_USER=
+DB_PASS=

--- a/.devcontainer/docker/README.md
+++ b/.devcontainer/docker/README.md
@@ -1,0 +1,6 @@
+# Devcontainer Folder (Configs Only, No Docker Runtime)
+
+This project keeps environment configs under `.devcontainer/` **for consistency and portability**, but we are **not using Docker/Dev Containers** during local development because it’s heavy on this machine.  
+Instead, we reuse the same config files directly on the host.
+
+I’ll Dockerize it down the road—once I get a new machine. My current laptop panics at the word container.

--- a/.devcontainer/docker/postgres/conf/README.md
+++ b/.devcontainer/docker/postgres/conf/README.md
@@ -1,0 +1,31 @@
+# PostgreSQL Local Setup (Linux, apt)
+
+Replace placeholders <...> with your actual values.
+
+## Steps
+
+1. `sudo apt update -y`
+2. `sudo apt install -y postgresql postgresql-contrib`
+3. `sudo -u postgres psql`
+4. `CREATE ROLE <username> LOGIN CREATEDB PASSWORD '<password>';`
+5. `CREATE DATABASE <username> OWNER <username>;`
+6. `CREATE ROLE <appname> LOGIN PASSWORD '<appname>';`
+7. `CREATE DATABASE <dbname> OWNER <appname> ENCODING 'UTF8';`
+8. `ALTER ROLE <username> WITH CREATEROLE CREATEDB;`
+9. `\q`
+10. `psql`
+
+## Connection test (app user)
+`psql -h localhost -U <appname> -d <dbname> -W`
+
+## etc
+`sudo cp .devcontainer/docker/postgres/conf/postgresql.dev.conf /etc/postgresql/<version>/main/`
+
+`sudo chmod 644 /etc/postgresql/<version>/main/postgresql.dev.conf`
+
+
+```postgresql.conf
+include_if_exists = 'postgresql.dev.conf'
+```
+
+`sudo systemctl restart postgresql`

--- a/.devcontainer/docker/postgres/conf/postgresql.dev.conf
+++ b/.devcontainer/docker/postgres/conf/postgresql.dev.conf
@@ -1,0 +1,14 @@
+max_connections = 8         # ★ Hikari(4)＋psql and etc...(buffer)
+shared_buffers  = 256MB
+work_mem        = 8MB   
+temp_buffers    = 8MB
+maintenance_work_mem = 128MB    
+
+# WAL/check point
+checkpoint_timeout = 15min
+max_wal_size       = 2GB
+wal_compression    = on
+
+# timezone
+timezone     = 'UTC'
+log_timezone = 'UTC'

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ bin/
 
 html/
 !html/.gitkeep
+
+.env

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,17 @@
     "java.configuration.updateBuildConfiguration": "automatic",
     "java.compile.nullAnalysis.mode": "automatic",
     "java.import.gradle.wrapper.enabled": true,
-    "files.autoGuessEncoding": true
+    "files.autoGuessEncoding": true,
+    "sqltools.connections": [
+        {
+            "previewLimit": 50,
+            "server": "localhost",
+            "port": 5432,
+            "driver": "PostgreSQL",
+            "name": "dev",
+            "database": "mps",
+            "username": "mps",
+            "password": "mps"
+        }
+    ]
 }

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,8 @@ subprojects {
         implementation 'org.mapstruct:mapstruct:1.6.3'
 
         developmentOnly 'org.springframework.boot:spring-boot-devtools'
-        developmentOnly 'com.h2database:h2'
+
+        runtimeOnly 'org.postgresql:postgresql'
 
         // https://stackoverflow.com/questions/53326271/spring-nullable-annotation-generates-unknown-enum-constant-warning
         compileOnly 'com.google.code.findbugs:jsr305:3.0.2'

--- a/mps-api/src/main/resources/application.yml
+++ b/mps-api/src/main/resources/application.yml
@@ -1,2 +1,19 @@
 server:
   port: 8080
+spring:
+  datasource:
+    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:db}
+    username: ${DB_USER:user}
+    password: ${DB_PASS:pass}
+    hikari:
+      maximum-pool-size: 4
+      minimum-idle: 2
+      idle-timeout: 600000
+      connection-timeout: 5000
+      pool-name: mps-api-pool
+    jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect

--- a/mps-api/src/main/resources/application.yml
+++ b/mps-api/src/main/resources/application.yml
@@ -2,9 +2,9 @@ server:
   port: 8080
 spring:
   datasource:
-    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:db}
-    username: ${DB_USER:user}
-    password: ${DB_PASS:pass}
+    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:mps}
+    username: ${DB_USER:mps}
+    password: ${DB_PASS:mps}
     hikari:
       maximum-pool-size: 4
       minimum-idle: 2


### PR DESCRIPTION
## Summary

Wire up **local PostgreSQL** for dev, keep configs under `.devcontainer/`, and point Spring Boot to PG using **env vars**. Swap out H2, add the PG driver, and document the host-based workflow. Dockerization will happen… once my laptop stops hyperventilating. 😅

## Description

* Add `.devcontainer/docker/.env.example` and docs; track `postgresql.dev.conf` (small-RAM preset).
* Copy conf via `conf.d`; restart PG; verify with `SHOW`—all in the README.
* App config: env-driven datasource (`DB_HOST/PORT/NAME/USER/PASS`) and Hikari settings.
* Gradle: add `runtimeOnly 'org.postgresql:postgresql'` (move off H2).
* Housekeeping: ignore `.env`, add a handy `SQLTools` connection.
* Future: will Dockerize when I upgrade the machine—current one panics at the word “container.”
