### PR TITLE
feat: GitHub housekeeping: Dependabot (grouped monthly), PR template, and workflows scaffold 🚿

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore:"
+    groups:
+      gradle-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+      gradle-major:
+        patterns: ["*"]
+        update-types: ["major"]
+    open-pull-requests-limit: 5
+  
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+    groups:
+      actions-all:
+        patterns: ["*"]  

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## Summary
+
+## Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+## Reference
+
+[original template](https://github.com/embeddedartistry/templates/blob/master/oss_docs/PULL_REQUEST_TEMPLATE/pull_request_template.md)


### PR DESCRIPTION
## Summary

Add repo-wide GitHub defaults: **Dependabot with grouped monthly updates**, a **PR template**, and a **workflows** scaffold. Fewer noisy bumps, cleaner PRs, and a tidy path to future CI. (Yes, my laptop still panics at the word “container.”)

## Description

* **Dependabot**: `gradle` + `github-actions` updates, **monthly**, labeled `dependencies`, commit prefix `chore:`, and **groups**

  * Gradle: one PR for **minor+patch**, one for **major**
  * Actions: **all-in-one** PR
* **PR template**: lightweight sections (`Summary`, `Description`, `Reference`) to keep reviews consistent.
* **Workflows scaffold**: add `.github/workflows/.gitkeep` to prep for CI without enabling it yet.

This trims dependency noise while giving us a consistent contribution flow—like cleaning the kitchen before we start cooking.
