### PR TITLE
chore(git): add pre-commit hook to auto-run Spotless

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+echo "→ Running Spotless: ./gradlew spotlessApply"
+./gradlew --quiet spotlessApply
+
+if ! git diff --quiet -- .; then
+  echo ""
+  echo "Spotless formatted files. Please add changes and commit again."
+  git status --short
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Add a `pre-commit` hook that runs `./gradlew spotlessApply` so code gets auto-formatted before commits. If Spotless changes files, the commit stops and asks you to stage the fixes—because future-you deserves prettier diffs.

## Description

* Adds `.githooks/pre-commit` that:

  * runs `spotlessApply`
  * aborts the commit if formatting modified files (you re-`add` and commit again)
* Keeps repos clean without CI minutes or reviewer tears.

**How to enable locally (once):**

```bash
git config core.hooksPath .githooks
# already executable in repo; if needed on Windows:
git update-index --chmod=+x .githooks/pre-commit
```

**Skip in emergencies:**

```bash
git commit --no-verify
```

**Note:** The hook uses `bash` and `set -o pipefail`. On environments where Git runs hooks with `sh` (some Windows setups), switch to a POSIX `sh` script variant.
