### PR TITLE
fix: handle missing proxy list in HTTP client pool

### DIFF
--- a/mps-api/src/main/java/com/mizegret/mps/mps_api/services/HttpServiceImpl.java
+++ b/mps-api/src/main/java/com/mizegret/mps/mps_api/services/HttpServiceImpl.java
@@ -35,6 +35,9 @@ public class HttpServiceImpl implements HttpService {
   @NonNull
   @Override
   public HttpResponse<byte[]> sendBytes(@NonNull HttpRequest request) throws Exception {
+    if (proxyRoutePool.isEmpty()) {
+      return defaultHttpClient.send(request, HttpResponse.BodyHandlers.ofByteArray());
+    }
     final ProxyRoute proxyRoute = proxyRoutePool.next();
     log.info("sending to {} via {}", request.uri(), proxyRoute.getProxy().getHost());
     return proxyRoute.getHttpClient().send(request, HttpResponse.BodyHandlers.ofByteArray());

--- a/mps-api/src/test/java/com/mizegret/mps/mps_api/proxy/ProxyRoutePoolTest.java
+++ b/mps-api/src/test/java/com/mizegret/mps/mps_api/proxy/ProxyRoutePoolTest.java
@@ -1,0 +1,15 @@
+package com.mizegret.mps.mps_api.proxy;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+class ProxyRoutePoolTest {
+
+  @Test
+  void missingResource_leadsToEmptyPool() throws IOException {
+    ProxyRoutePool pool = new ProxyRoutePool();
+    assertTrue(pool.isEmpty());
+  }
+}

--- a/mps-api/src/test/java/com/mizegret/mps/mps_api/services/HttpServiceImplTest.java
+++ b/mps-api/src/test/java/com/mizegret/mps/mps_api/services/HttpServiceImplTest.java
@@ -1,0 +1,44 @@
+package com.mizegret.mps.mps_api.services;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.*;
+
+import com.mizegret.mps.mps_api.proxy.ProxyRoutePool;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class HttpServiceImplTest {
+
+  @Mock private ProxyRoutePool proxyRoutePool;
+  @Mock private HttpClient defaultHttpClient;
+  @Mock private HttpRequest httpRequest;
+  @Mock private HttpResponse<byte[]> httpResponse;
+
+  @InjectMocks private HttpServiceImpl httpService;
+
+  @BeforeEach
+  void setUp() {
+    // ensure inject mocks occurs
+  }
+
+  @Test
+  void sendBytes_withoutProxies_usesDefaultClient() throws Exception {
+    when(proxyRoutePool.isEmpty()).thenReturn(true);
+    when(defaultHttpClient.send(eq(httpRequest), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+
+    HttpResponse<byte[]> res = httpService.sendBytes(httpRequest);
+
+    assertSame(httpResponse, res);
+    verify(defaultHttpClient).send(eq(httpRequest), any(HttpResponse.BodyHandler.class));
+    verify(proxyRoutePool, never()).next();
+  }
+}


### PR DESCRIPTION
## Summary
- avoid `NullPointerException` when `proxy-list.txt` is missing and log warning
- fall back to default `HttpClient` when no proxies are configured
- add unit tests for proxy pool and HTTP service

## Testing
- `./gradlew test`
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_689c60c94010832f8589b84ceeebb3b2